### PR TITLE
Fix: ensure dummy task is a callable object.

### DIFF
--- a/pylint_celery/__init__.py
+++ b/pylint_celery/__init__.py
@@ -24,7 +24,9 @@ MANAGER.register_transform(nodes.Module, transform)
 
 def celery_transform(module):
     fake = AstroidBuilder(MANAGER).string_build('''
-class task_dummy(object): pass
+class task_dummy(object):
+	def __call__(self):
+		pass
 ''')
     module.locals['task'] = fake.locals['task_dummy']
 

--- a/test/input/func_noerror_celery.py
+++ b/test/input/func_noerror_celery.py
@@ -8,3 +8,6 @@ from celery import task
 @task(queue='celery')
 def test_task(an_arg, another_arg):
     return an_arg + another_arg
+
+
+TEST_TASK_NON_DECORATOR = task(ignore_results=True)(lambda: 0)


### PR DESCRIPTION
This takes care of the warning in a senario where
a task object is used without the decorator
syntax.
