### PR TITLE
Replace last logilab-common bits with unittest

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,10 +3,10 @@ python:
   - "2.6"
   - "2.7"
 install:
-  - "pip install --use-mirrors coverage coveralls"
-  - "pip install --use-mirrors -r test_requirements.txt"
-  - "pip install --use-mirrors git+https://github.com/landscapeio/pylint-plugin-utils.git@develop"
-  - "pip install --use-mirrors --editable ."
+  - "pip install coverage coveralls"
+  - "pip install -r test_requirements.txt"
+  - "pip install git+https://github.com/landscapeio/pylint-plugin-utils.git@develop"
+  - "pip install --editable ."
 script:
   coverage run test/test_func.py
 after_success:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,8 @@
 language: python
 python:
-  - "2.6"
   - "2.7"
+  - "3.4"
+  - "3.5"
 install:
   - "pip install coverage coveralls"
   - "pip install -r test_requirements.txt"

--- a/test/test_func.py
+++ b/test/test_func.py
@@ -1,7 +1,6 @@
 
 from os.path import join, dirname, abspath
 import unittest
-from logilab.common import testlib
 from pylint.testutils import make_tests, LintTestUsingModule, LintTestUsingFile, cb_test_gen, linter
 import sys
 
@@ -17,14 +16,14 @@ linter.global_set_option('required-attributes', ())  # remove required __revisio
 
 
 def suite():
-    return testlib.TestSuite([unittest.makeSuite(test, suiteClass=testlib.TestSuite)
-                              for test in make_tests(INPUT_DIR, MESSAGES_DIR,
-                                                     FILTER_RGX, CALLBACKS)])
+    return unittest.TestSuite([unittest.makeSuite(test, suiteClass=unittest.TestSuite)
+                               for test in make_tests(INPUT_DIR, MESSAGES_DIR,
+                                                      FILTER_RGX, CALLBACKS)])
 
 if __name__=='__main__':
     if len(sys.argv) > 1:
         FILTER_RGX = sys.argv[1]
         del sys.argv[1]
-    testlib.unittest_main(defaultTest='suite')
+    unittest.main(defaultTest='suite')
 
 


### PR DESCRIPTION
`pylint` no longer depends on `logilab-common`, so let's get rid of the last bits of `logilab-common` in `pylint-celery` as well. The PR also updates the list of tested Python version for Travis CI.