### PR TITLE
Switched broken pypip.in badges to shields.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,8 +4,8 @@ pylint-celery
 [![Build Status](https://travis-ci.org/landscapeio/pylint-celery.png?branch=master)](https://travis-ci.org/landscapeio/pylint-celery)
 [![Code Quality](https://landscape.io/github/landscapeio/pylint-celery/master/landscape.png)](https://landscape.io/github/landscapeio/pylint-celery)
 [![Coverage Status](https://coveralls.io/repos/landscapeio/pylint-celery/badge.png)](https://coveralls.io/r/landscapeio/pylint-celery)
-[![Latest Version](https://pypip.in/v/pylint-celery/badge.png)](https://crate.io/packages/pylint-celery)
-[![Downloads](https://pypip.in/d/pylint-celery/badge.png)](https://crate.io/packages/pylint-celery)
+[![Latest Version](https://img.shields.io/pypi/v/pylint-celery.svg)](https://crate.io/packages/pylint-celery)
+[![Downloads](https://img.shields.io/pypi/dm/pylint-celery.svg)](https://crate.io/packages/pylint-celery)
 
 # About
 


### PR DESCRIPTION
Hello, this is an auto-generated Pull Request. ([Feedback?](mailto:repobot@movermeyer.com?subject=pypip.in%20Badge%20Bot%20Feedback%3A%20pylint-celery))

Some time ago, [pypip.in](https://web.archive.org/web/20150318013508/https://pypip.in/) shut down. This broke the badges for a bunch of repositories, including `pylint-celery`. Thankfully, an equivalent service is run by [shields.io](https://shields.io). This pull request changes the badges to use shields.io instead.

Unfortunately, [PyPI has removed download statistics from their API](https://mail.python.org/pipermail/distutils-sig/2013-May/020855.html), which means that even the shields.io "download count" badges are broken (they display "no longer available". See [this](https://github.com/badges/shields/issues/716)). So those badges should really be removed entirely. Since this is an automated process (and trying to automatically remove the badges from READMEs can be tricky), this pull request just replaces the URL with the shields.io syntax.