### PR TITLE
Import setup from setuptools

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,5 @@
 # -*- coding: UTF-8 -*-
-from distutils.core import setup
-from setuptools import find_packages
+from setuptools import find_packages, setup
 
 _version = "0.3"
 _packages = find_packages(exclude=["*.tests", "*.tests.*", "tests.*", "tests"])


### PR DESCRIPTION
setuptools 60 uses its own bundled version of distutils, by default. It injects this into sys.modules, at import time. So we need to make sure that it is imported, before anything else imports distutils, to ensure everything is using the same distutils version.

This change in setuptools is to prepare for Python 3.12, which will drop distutils.

In this case, the best way to deal with the problem is to just use setuptools' setup().

Fixes: https://bugs.debian.org/1022481